### PR TITLE
Adds libretto context map in create requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ async function main() {
       promptTemplateName: "ts-client-test-chat",
       // The parameters to fill in the template.
       templateParams: { name: "John" },
-      //optional: metadata for passing custom tracking information
+      //optional: key/value for passing any additional information for tracing
       metadata: { someKey: "somevalue" },
     },
   });

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ async function main() {
       promptTemplateName: "ts-client-test-chat",
       // The parameters to fill in the template.
       templateParams: { name: "John" },
+      //optional: metadata for passing custom tracking information
+      metadata: { someKey: "somevalue" },
     },
   });
 
@@ -95,6 +97,8 @@ added to the base OpenAI `create` call interface:
 - `feedbackKey`: The optional key used to send feedback on the prompt, for
   use with `sendFeedback()` later. This is normally auto-generated, and the
   value is returned in the OpenAI response.
+- `metadata`: This optional key/value map lets you send additional information
+  along with your request such as internal tracing IDs, user IDs etc.
 
 ## Sending Feedback
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ async function main() {
       // The parameters to fill in the template.
       templateParams: { name: "John" },
       //optional: key/value for passing any additional information for tracing
-      metadata: { someKey: "somevalue" },
+      context: { someKey: "somevalue" },
     },
   });
 
@@ -97,7 +97,7 @@ added to the base OpenAI `create` call interface:
 - `feedbackKey`: The optional key used to send feedback on the prompt, for
   use with `sendFeedback()` later. This is normally auto-generated, and the
   value is returned in the OpenAI response.
-- `metadata`: This optional key/value map lets you send additional information
+- `context`: This optional key/value map lets you send additional information
   along with your request such as internal tracing IDs, user IDs etc.
 
 ## Sending Feedback

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@libretto/openai",
   "main": "lib/src/index.js",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "types": "lib/src/index.d.ts",
   "scripts": {
     "build": "tsc",

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -116,7 +116,7 @@ export class LibrettoCompletions extends Completions {
         chatId: libretto?.chatId ?? this.config.chatId,
         parentEventId: libretto?.parentEventId,
         feedbackKey,
-        metadata: libretto?.metadata,
+        context: libretto?.context,
         modelParameters: {
           modelProvider: "openai",
           modelType: "completion",

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -132,7 +132,7 @@ export class LibrettoCompletions extends Completions {
         });
       },
     );
-      
+
     return returnValue as Completion | Stream<Completion>;
   }
 }

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -116,6 +116,7 @@ export class LibrettoCompletions extends Completions {
         chatId: libretto?.chatId ?? this.config.chatId,
         parentEventId: libretto?.parentEventId,
         feedbackKey,
+        metadata: libretto?.metadata,
         modelParameters: {
           modelProvider: "openai",
           modelType: "completion",

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,13 +21,13 @@ type LibrettoCreateParams = {
   chatId?: string;
   parentEventId?: string;
   feedbackKey?: string;
-  metadata?: Record<string, any>;
+  context?: Record<string, any>;
 };
 
 //todo: should we mark these as readonly?
 type LibrettoCompletion = {
   feedbackKey?: string;
-  metadata?: Record<string, any>;
+  context?: Record<string, any>;
 };
 
 declare module "openai" {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,10 +21,13 @@ type LibrettoCreateParams = {
   chatId?: string;
   parentEventId?: string;
   feedbackKey?: string;
+  metadata?: Record<string, any>;
 };
 
+//todo: should we mark these as readonly?
 type LibrettoCompletion = {
   feedbackKey?: string;
+  metadata?: Record<string, any>;
 };
 
 declare module "openai" {

--- a/src/session.ts
+++ b/src/session.ts
@@ -36,6 +36,7 @@ export interface EventMetadata {
   parentEventId?: string;
   modelParameters?: ModelParameters;
   feedbackKey?: string;
+  metadata?: Record<string, any>;
   tools?: any[];
 }
 export interface PromptEvent {

--- a/src/session.ts
+++ b/src/session.ts
@@ -36,7 +36,7 @@ export interface EventMetadata {
   parentEventId?: string;
   modelParameters?: ModelParameters;
   feedbackKey?: string;
-  metadata?: Record<string, any>;
+  context?: Record<string, any>;
   tools?: any[];
 }
 export interface PromptEvent {


### PR DESCRIPTION
`context` property in libretto creation types to let users add dynamic key/value information for their own use cases (e.g. appending their internal request IDs, user specific IDs etc.)