### PR TITLE
Send usage, finish_reason, and logprobs through our events api

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@libretto/openai",
   "main": "lib/src/index.js",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "types": "lib/src/index.d.ts",
   "scripts": {
     "build": "tsc",

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -94,44 +94,48 @@ class LibrettoChatCompletions extends Completions {
     );
 
     // note: not awaiting the result of this
-    finalResultPromise.then(async ({ response }) => {
-      const responseTime = Date.now() - now;
-      let params = libretto?.templateParams ?? {};
+    finalResultPromise.then(
+      async ({ response, finish_reason, logprobs, usage }) => {
+        const responseTime = Date.now() - now;
+        let params = libretto?.templateParams ?? {};
 
-      // Redact PII before recording the event
-      if (this.piiRedactor) {
-        try {
-          response = this.piiRedactor.redact(response);
-          params = this.piiRedactor.redact(params);
-        } catch (err) {
-          console.log("Failed to redact PII", err);
+        // Redact PII before recording the event
+        if (this.piiRedactor) {
+          try {
+            response = this.piiRedactor.redact(response);
+            params = this.piiRedactor.redact(params);
+          } catch (err) {
+            console.log("Failed to redact PII", err);
+          }
         }
-      }
 
-      await send_event({
-        responseTime,
-        response,
-        params: params,
-        apiKey:
-          libretto?.apiKey ??
-          this.config.apiKey ??
-          process.env.LIBRETTO_API_KEY,
-        promptTemplateChat:
-          libretto?.templateChat ?? template ?? resolvedMessages,
-        promptTemplateName: resolvedPromptTemplateName,
-        apiName: libretto?.promptTemplateName ?? this.config.promptTemplateName,
-        prompt: {},
-        chatId: libretto?.chatId ?? this.config.chatId,
-        parentEventId: libretto?.parentEventId,
-        feedbackKey,
-        modelParameters: {
-          modelProvider: "openai",
-          modelType: "chat",
-          ...openaiBody,
-        },
-        tools: tools,
-      });
-    });
+        await send_event({
+          responseTime,
+          response,
+          responseMetrics: { usage, finish_reason, logprobs },
+          params: params,
+          apiKey:
+            libretto?.apiKey ??
+            this.config.apiKey ??
+            process.env.LIBRETTO_API_KEY,
+          promptTemplateChat:
+            libretto?.templateChat ?? template ?? resolvedMessages,
+          promptTemplateName: resolvedPromptTemplateName,
+          apiName:
+            libretto?.promptTemplateName ?? this.config.promptTemplateName,
+          prompt: {},
+          chatId: libretto?.chatId ?? this.config.chatId,
+          parentEventId: libretto?.parentEventId,
+          feedbackKey,
+          modelParameters: {
+            modelProvider: "openai",
+            modelType: "chat",
+            ...openaiBody,
+          },
+          tools: tools,
+        });
+      },
+    );
     return returnValue as ChatCompletion | Stream<ChatCompletionChunk>;
   }
 }

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -13,8 +13,8 @@ import {
 } from "openai/resources/chat/completions";
 import { Stream } from "openai/streaming";
 import { LibrettoConfig, send_event } from ".";
-import { getResolvedMessages, getResolvedStream } from "./resolvers";
 import { PiiRedactor } from "./pii";
+import { getResolvedMessages, getResolvedStream } from "./resolvers";
 
 export class LibrettoChat extends Chat {
   constructor(
@@ -94,7 +94,7 @@ class LibrettoChatCompletions extends Completions {
     );
 
     // note: not awaiting the result of this
-    finalResultPromise.then(async (response) => {
+    finalResultPromise.then(async ({ response }) => {
       const responseTime = Date.now() - now;
       let params = libretto?.templateParams ?? {};
 

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -11,8 +11,8 @@ import {
 } from "openai/resources/completions";
 import { Stream } from "openai/streaming";
 import { LibrettoConfig, send_event } from ".";
-import { getResolvedPrompt, getResolvedStream } from "./resolvers";
 import { PiiRedactor } from "./pii";
+import { getResolvedPrompt, getResolvedStream } from "./resolvers";
 
 export class LibrettoCompletions extends Completions {
   protected piiRedactor?: PiiRedactor;
@@ -86,7 +86,7 @@ export class LibrettoCompletions extends Completions {
     );
 
     // note: not awaiting the result of this
-    finalResultPromise.then(async (response) => {
+    finalResultPromise.then(async ({ response }) => {
       const responseTime = Date.now() - now;
       let params = libretto?.templateParams ?? {};
 

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -4,6 +4,11 @@ import { ChatCompletionMessageParam } from "openai/resources/chat";
 import { Stream } from "openai/streaming";
 import { ObjectTemplate } from "./template";
 
+interface ResolvedAPIResult {
+  response: string | null | undefined;
+  usage: OpenAI.Completions.CompletionUsage | undefined;
+}
+
 /** This function papers over the difference between streamed and unstreamed
  * responses. It splits the response into two parts:
  * 1. The return value, which is what the caller should return immediately (may
@@ -28,7 +33,7 @@ export async function getResolvedStream(
     | Stream<OpenAI.Completions.Completion>
     | OpenAI.Chat.Completions.ChatCompletion
     | OpenAI.Completions.Completion;
-  finalResultPromise: Promise<{ response: string | null | undefined }>;
+  finalResultPromise: Promise<ResolvedAPIResult>;
 }> {
   if (stream) {
     const chunkStream = (await resultPromise) as
@@ -75,15 +80,16 @@ type PromptString = string | string[] | number[] | number[][] | null;
 
 function getStaticChatCompletion(
   result: OpenAI.Chat.Completions.ChatCompletion,
-) {
+): ResolvedAPIResult {
   if (result.choices[0].message.content) {
-    return { response: result.choices[0].message.content };
+    return { response: result.choices[0].message.content, usage: result.usage };
   }
   if (result.choices[0].message.function_call) {
     return {
       response: JSON.stringify({
         function_call: result.choices[0].message.function_call,
       }),
+      usage: result.usage,
     };
   }
   if (result.choices[0].message.tool_calls) {
@@ -91,19 +97,22 @@ function getStaticChatCompletion(
       response: JSON.stringify({
         tool_calls: result.choices[0].message.tool_calls,
       }),
+      usage: result.usage,
     };
   }
-  return { response: undefined };
+  return { response: undefined, usage: result.usage };
 }
 
-function getStaticCompletion(result: OpenAI.Completions.Completion | null) {
+function getStaticCompletion(
+  result: OpenAI.Completions.Completion | null,
+): ResolvedAPIResult {
   if (!result) {
-    return { response: null };
+    return { response: null, usage: undefined };
   }
   if (result.choices[0].text) {
-    return { response: result.choices[0].text };
+    return { response: result.choices[0].text, usage: result.usage };
   }
-  return { response: undefined };
+  return { response: undefined, usage: result.usage };
 }
 export function getResolvedMessages(
   messages:
@@ -156,10 +165,10 @@ class WrappedStream<
     | OpenAI.Chat.Completions.ChatCompletionChunk
     | OpenAI.Completions.Completion,
 > extends Stream<T> {
-  finishPromise: Promise<{ response: string }>;
-  private resolveIterator!: (v: { response: string }) => void;
+  finishPromise: Promise<ResolvedAPIResult>;
+  private resolveIterator!: (v: ResolvedAPIResult) => void;
   private accumulatedResult: string[] = [];
-  private responseParameters: any;
+  private responseUsage: OpenAI.Completions.CompletionUsage | undefined;
   isChat: boolean;
   feedbackKey: string;
 
@@ -195,6 +204,9 @@ class WrappedStream<
               JSON.stringify(chatItem.choices[0].delta.function_call),
             );
           }
+          // TODO: get usage from streaming chat. This is currently missing from the API!
+          // https://community.openai.com/t/openai-api-get-usage-tokens-in-response-when-set-stream-true/141866
+          // https://community.openai.com/t/chat-completion-stream-api-token-usage/352964
         } else {
           const completionItem = item as OpenAI.Completions.Completion;
           if (!completionItem.libretto) {
@@ -202,11 +214,15 @@ class WrappedStream<
           }
           completionItem.libretto.feedbackKey = this.feedbackKey;
           this.accumulatedResult.push(completionItem.choices[0].text);
+          this.responseUsage = completionItem.usage;
         }
         yield item;
       }
     } finally {
-      this.resolveIterator({ response: this.accumulatedResult.join("") });
+      this.resolveIterator({
+        response: this.accumulatedResult.join(""),
+        usage: this.responseUsage,
+      });
     }
   }
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -119,13 +119,13 @@ export interface Feedback {
 /** Send feedback to the  */
 export async function sendFeedback(body: Feedback) {
   if (!body.feedbackKey) {
-    console.log("Could not send feedback to Libretto: missing feedback key");
+    console.warn("Could not send feedback to Libretto: missing feedback key");
     return;
   }
 
   body.apiKey = body.apiKey ?? process.env.LIBRETTO_API_KEY;
   if (!body.apiKey) {
-    console.log("Could not send feedback to Libretto: missing API key");
+    console.warn("Could not send feedback to Libretto: missing API key");
     return;
   }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,4 +1,8 @@
-import { type CompletionCreateParamsNonStreaming } from "openai/resources";
+import OpenAI from "openai";
+import {
+  type CompletionCreateParamsNonStreaming,
+  type CompletionUsage,
+} from "openai/resources";
 import { type ChatCompletionCreateParamsNonStreaming } from "openai/resources/chat";
 
 function getUrl(apiName: string, environmentName: string): string {
@@ -46,6 +50,20 @@ export interface PromptEvent {
   responseTime?: number;
   /** Included only if there is an error from openai, or error in validation */
   responseErrors?: string[];
+
+  responseMetrics?: {
+    usage: CompletionUsage | undefined;
+    finish_reason:
+      | OpenAI.Completions.CompletionChoice["finish_reason"]
+      | OpenAI.ChatCompletion.Choice["finish_reason"]
+      | undefined
+      | null;
+    logprobs:
+      | OpenAI.Completions.CompletionChoice.Logprobs
+      | OpenAI.Chat.Completions.ChatCompletion.Choice.Logprobs
+      | undefined
+      | null;
+  };
   // eslint-disable-next-line @typescript-eslint/ban-types
   prompt: {}; //hack
 }


### PR DESCRIPTION
Cannot land until the backend supports this new field.

- wrap response in {response:..} envelop
- include usage
- add finish_reason and logprobs
- send responseMetrics with event
