### PR TITLE
Require all variables when formatting

### DIFF
--- a/src/template.test.ts
+++ b/src/template.test.ts
@@ -10,14 +10,18 @@ describe("templating", () => {
       const a = "a";
       const b = "b";
       const c = "c";
-      expect(() => f`${a} ${b} ${c}`.variables).toThrowError(
-        "No inline variables",
-      );
+      expect(() => f`${a} ${b} ${c}`.variables).toThrow("No inline variables");
     });
 
     it("Should format to a string", () => {
       expect(f`{a} {b} {c}`.format({ a: "A", b: "B", c: "C" })).toEqual(
         "A B C",
+      );
+    });
+
+    it("Should throw an error if any variable is missing during formatting", () => {
+      expect(() => f`{a} {b} {c}`.format({ a: "A", c: "C" })).toThrow(
+        "missing variable",
       );
     });
   });

--- a/src/template.ts
+++ b/src/template.ts
@@ -52,6 +52,11 @@ export function f(
   return {
     format(parameters: Record<string, any>) {
       return str.replace(templateExpressionVarName, (match, variableName) => {
+        if (parameters[variableName] === undefined) {
+          throw new Error(
+            `Can't format template, missing variable: ${variableName}`,
+          );
+        }
         return parameters[variableName];
       });
     },


### PR DESCRIPTION
Resolves #81. See https://github.com/libretto-ai/prompt-js/issues/1950 for one impact this was having.

Prior behavior would substitute the string `undefined` in this case.