### PR TITLE
Unescape previously escaped variables

### DIFF
--- a/src/template.test.ts
+++ b/src/template.test.ts
@@ -161,5 +161,32 @@ describe("templating", () => {
         },
       ]);
     });
+
+    it("Should unescape escaped variable references", () => {
+      expect(
+        objectTemplate({
+          a: "A here: \\{a\\}",
+          b: "B here: \\{b\\}",
+          c: { d: "D here: \\{d\\}", e: "E here: \\{e\\}" },
+        }).format({}),
+      ).toEqual({
+        a: "A here: {a}",
+        b: "B here: {b}",
+        c: { d: "D here: {d}", e: "E here: {e}" },
+      });
+    });
+    it("Should allow mixing of escaped and unescaped variable references", () => {
+      expect(
+        objectTemplate({
+          a: "A here: \\{a\\} but this is the value of a: {a}",
+          b: "B here: \\{b\\}",
+          c: { d: "D here: \\{d\\}", e: "E here: \\{e\\}" },
+        }).format({ a: "Heya" }),
+      ).toEqual({
+        a: "A here: {a} but this is the value of a: Heya",
+        b: "B here: {b}",
+        c: { d: "D here: {d}", e: "E here: {e}" },
+      });
+    });
   });
 });

--- a/src/template.ts
+++ b/src/template.ts
@@ -4,8 +4,8 @@
 const templateExpression = /({[a-zA-Z0-9_[\].]+})/g;
 /** Match the variable inside a template expression, e.g. the 'foo' in 'replace {foo} now' */
 const templateExpressionVarName = /{([a-zA-Z0-9_[\].]+)}/g;
-/** Unescape variable names, e.g. if the template originally contained \\{foo\\}
- * to avoid substitutions, then replace it again with {foo} */
+/** Unescape variable names, e.g. if the template originally contained `\{foo\}`
+ * to avoid substitutions, then replace it again with `{foo}` */
 const unescapeVariableExpression = /\\{([a-zA-Z0-9_[\].]+)\\}/g;
 // We have a special keyword that we use to expand out an array for a chat_history argument
 const CHAT_HISTORY = "chat_history";

--- a/src/template.ts
+++ b/src/template.ts
@@ -60,14 +60,19 @@ export function f(
   );
   return {
     format(parameters: Record<string, any>) {
-      return str.replace(templateExpressionVarName, (match, variableName) => {
-        if (parameters[variableName] === undefined) {
-          throw new Error(
-            `Can't format template, missing variable: ${variableName}`,
-          );
-        }
-        return parameters[variableName];
-      });
+      return str
+        .replace(templateExpressionVarName, (match, variableName) => {
+          if (parameters[variableName] === undefined) {
+            throw new Error(
+              `Can't format template, missing variable: ${variableName}`,
+            );
+          }
+          return parameters[variableName];
+        })
+        .replace(
+          unescapeVariableExpression,
+          (_match, variableName) => `{${variableName}}`,
+        );
     },
     variables: Object.freeze(variables),
     template: str,
@@ -124,12 +129,7 @@ export function objectTemplate<T>(objs: T): ObjectTemplate<T> {
       return objs;
     }
     if (typeof objs == "string") {
-      const formattedResult = f(objs).format(parameters);
-
-      return formattedResult.replace(
-        unescapeVariableExpression,
-        (_match, variableName) => `{${variableName}}`,
-      ) as T;
+      return f(objs).format(parameters) as T;
     }
     if (Array.isArray(objs)) {
       return objs.flatMap((item) => {


### PR DESCRIPTION
- **unescape variable references after formatting**
- **move unescaping up to format()**
