### PR TITLE
Add support for deleting assistant thread messages

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,0 +1,71 @@
+import OpenAI from "openai";
+import { APIPromise, RequestOptions } from "openai/core";
+import {
+  Message,
+  MessageDeleted,
+  Messages,
+} from "openai/resources/beta/threads/messages";
+import { LibrettoConfig, sendFeedback } from ".";
+import { LibrettoThreads } from "./threads";
+
+export class LibrettoMessages extends Messages {
+  constructor(
+    protected client: OpenAI,
+    protected config: LibrettoConfig,
+  ) {
+    super(client);
+  }
+
+  override del(
+    threadId: string,
+    messageId: string,
+    options?: RequestOptions | undefined,
+  ): APIPromise<MessageDeleted> {
+    return this._del(
+      threadId,
+      messageId,
+      options,
+    ) as APIPromise<MessageDeleted>;
+  }
+
+  private async _del(
+    threadId: string,
+    messageId: string,
+    options?: RequestOptions | undefined,
+  ): Promise<MessageDeleted> {
+    // Check if the message being deleted is the current thread cursor.
+    // If it is, we need to update the cursor before allowing the message to be deleted.
+    const cursor = await (
+      this.client.beta.threads as LibrettoThreads
+    ).getCursor(threadId);
+    if (cursor === messageId) {
+      const prevMessage = await this.findPreviousMessage(threadId, messageId);
+      const newCursor = prevMessage !== null ? prevMessage.id : "";
+      await (this.client.beta.threads as LibrettoThreads).setCursor(
+        threadId,
+        newCursor,
+      );
+    }
+
+    // Mark the message as deleted in Libretto
+    await sendFeedback({
+      feedbackKey: messageId,
+      isDeleted: true,
+    });
+
+    return super.del(threadId, messageId, options);
+  }
+
+  private async findPreviousMessage(
+    threadId: string,
+    messageId: string,
+  ): Promise<Message | null> {
+    const messagePage = await this.client.beta.threads.messages.list(threadId, {
+      after: messageId,
+      order: "desc",
+      limit: 1,
+    });
+    const messages = messagePage.data;
+    return messages.length > 0 ? messages[0] : null;
+  }
+}

--- a/src/session.ts
+++ b/src/session.ts
@@ -114,6 +114,13 @@ export interface Feedback {
    */
   betterResponse?: string;
 
+  /**
+   * Indicates that an event is "deleted." Used when assistant thread messages
+   * were deleted in OpenAI -- we keep the original message event but mark it
+   * as deleted via feedback.
+   */
+  isDeleted?: boolean;
+
   apiKey?: string;
 }
 
@@ -135,6 +142,7 @@ export async function sendFeedback(body: Feedback) {
     Object.entries(body).map(([k, v]) => {
       if (k === "feedbackKey") return ["feedback_key", v];
       if (k === "betterResponse") return ["better_response", v];
+      if (k === "isDeleted") return ["is_deleted", v];
       return [k, v];
     }),
   );

--- a/src/threads.ts
+++ b/src/threads.ts
@@ -1,14 +1,32 @@
 import OpenAI from "openai";
 import { Threads } from "openai/resources/beta/threads/threads";
 import { LibrettoConfig } from ".";
+import { LibrettoMessages } from "./messages";
 import { LibrettoRuns } from "./runs";
+
+const LIBRETTO_THREAD_CURSOR_KEY = "libretto.cursor";
 
 export class LibrettoThreads extends Threads {
   constructor(
-    client: OpenAI,
+    protected client: OpenAI,
     protected config: LibrettoConfig,
   ) {
     super(client);
     this.runs = new LibrettoRuns(client, config);
+    this.messages = new LibrettoMessages(client, config);
+  }
+
+  public async getCursor(threadId: string) {
+    const thread = await this.client.beta.threads.retrieve(threadId);
+    const threadMetadata = (thread.metadata as Record<string, any>) ?? {};
+    return threadMetadata[LIBRETTO_THREAD_CURSOR_KEY] ?? "";
+  }
+
+  public async setCursor(threadId: string, val: string) {
+    await this.client.beta.threads.update(threadId, {
+      metadata: {
+        [LIBRETTO_THREAD_CURSOR_KEY]: val,
+      },
+    });
   }
 }


### PR DESCRIPTION
This PR makes two changes related to message deletion:
1. When an assistant thread message is deleted, we first check to see if that message ID is the current value of the thread cursor. If it is, we update the cursor to point at the message immediately prior in the thread (if such a message exists, we clear the cursor otherwise).
2. We send feedback to Libretto indicating that the message was deleted so that it can be reflected in the UI