### PR TITLE
Make objectTemplate more typesafe, and use private symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ async function main() {
     // Instead of a chat message array, you can pass objectTemplate instead.
     messages: objectTemplate([
       { role: "user", content: "Give a hearty welcome to our new user {name}" },
-    ]) as any,
+    ]),
     model: "gpt-3.5-turbo",
     libretto: {
       // Uniquely identifies this prompt within your project.

--- a/examples/chathistory.ts
+++ b/examples/chathistory.ts
@@ -1,3 +1,4 @@
+import { ChatCompletionMessageParam } from "openai/resources";
 import { objectTemplate } from "../src";
 import { OpenAI } from "../src/client";
 
@@ -21,7 +22,7 @@ async function main() {
         role: "user",
         content: "{coach_question}",
       },
-    ]) as any,
+    ]) as ChatCompletionMessageParam[],
     model: "gpt-3.5-turbo",
     temperature: 1,
     libretto: {

--- a/examples/chathistory.ts
+++ b/examples/chathistory.ts
@@ -22,7 +22,7 @@ async function main() {
         role: "user",
         content: "{coach_question}",
       },
-    ]) as ChatCompletionMessageParam[],
+    ]) as ChatCompletionMessageParam[], // need to cast because of chat_history
     model: "gpt-3.5-turbo",
     temperature: 1,
     libretto: {

--- a/examples/simple.ts
+++ b/examples/simple.ts
@@ -10,7 +10,7 @@ async function main() {
   const completion = await openai.chat.completions.create({
     messages: objectTemplate([
       { role: "user", content: "Say this is a test to {name}" },
-    ]) as any,
+    ]),
     model: "gpt-3.5-turbo",
     libretto: {
       promptTemplateName: "ts-client-test-chat",

--- a/examples/simplestream.ts
+++ b/examples/simplestream.ts
@@ -11,7 +11,7 @@ async function main() {
   const completion = await openai.chat.completions.create({
     messages: objectTemplate([
       { role: "user", content: "Tell a 20 word story about {name}" },
-    ]) as any,
+    ]),
     model: "gpt-3.5-turbo",
     stream: true,
     libretto: {
@@ -26,7 +26,7 @@ async function main() {
   console.log("Testing Streaming Completion API...");
   const completion2 = await openai.completions.create({
     prompt: f`Tell a 20 word story about {name}` as unknown as string,
-    model: "davinci",
+    model: "gpt-3.5-turbo-instruct",
     stream: true,
     libretto: {
       promptTemplateName: "ts-client-test-chat",

--- a/examples/tools.ts
+++ b/examples/tools.ts
@@ -1,5 +1,5 @@
-import { OpenAI } from "../src/client";
 import { objectTemplate } from "../src";
+import { OpenAI } from "../src/client";
 
 async function main() {
   const openai = new OpenAI({
@@ -13,7 +13,7 @@ async function main() {
         role: "user",
         content: "What's the weather like in {location}?",
       },
-    ]) as any,
+    ]),
     model: "gpt-3.5-turbo",
     tools: [
       {

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -3,10 +3,10 @@ import { APIPromise } from "openai/core";
 import { ChatCompletionMessageParam } from "openai/resources/chat";
 import { Stream } from "openai/streaming";
 import {
-  formatProp,
+  formatTemplate,
+  getTemplate,
   isObjectTemplate,
   ObjectTemplate,
-  templateProp,
 } from "./template";
 
 export interface ToolCallAsJsonFragment {
@@ -188,8 +188,8 @@ export function getResolvedMessages(
     if (!params) {
       throw new Error(`Template requires params, but none were provided`);
     }
-    const resolvedMessages = messages[formatProp](params);
-    return { messages: resolvedMessages, template: messages[templateProp] };
+    const resolvedMessages = formatTemplate(messages, params);
+    return { messages: resolvedMessages, template: getTemplate(messages) };
   }
   return { messages, template: null };
 }
@@ -218,8 +218,8 @@ export function getResolvedPrompt(
     if (!params) {
       throw new Error(`Template requires params, but none were provided`);
     }
-    const resolvedPrompt = s[formatProp](params);
-    return { prompt: resolvedPrompt, template: s[templateProp] };
+    const resolvedPrompt = formatTemplate(s, params);
+    return { prompt: resolvedPrompt, template: getTemplate(s) };
   }
   return { prompt: s, template: null };
 }

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -2,7 +2,12 @@ import OpenAI from "openai";
 import { APIPromise } from "openai/core";
 import { ChatCompletionMessageParam } from "openai/resources/chat";
 import { Stream } from "openai/streaming";
-import { ObjectTemplate } from "./template";
+import {
+  formatProp,
+  isObjectTemplate,
+  ObjectTemplate,
+  templateProp,
+} from "./template";
 
 export interface ToolCallAsJsonFragment {
   id: string | undefined;
@@ -179,12 +184,12 @@ export function getResolvedMessages(
     | ObjectTemplate<ChatCompletionMessageParam[]>,
   params?: Record<string, any>,
 ) {
-  if ("template" in messages && "format" in messages) {
+  if (isObjectTemplate(messages)) {
     if (!params) {
       throw new Error(`Template requires params, but none were provided`);
     }
-    const resolvedMessages = messages.format(params);
-    return { messages: resolvedMessages, template: messages.template };
+    const resolvedMessages = messages[formatProp](params);
+    return { messages: resolvedMessages, template: messages[templateProp] };
   }
   return { messages, template: null };
 }
@@ -209,12 +214,12 @@ export function getResolvedPrompt(
   if (!s) {
     return { prompt: s, template: null };
   }
-  if ("template" in s && "format" in s) {
+  if (isObjectTemplate(s)) {
     if (!params) {
       throw new Error(`Template requires params, but none were provided`);
     }
-    const resolvedPrompt = s.format(params);
-    return { prompt: resolvedPrompt, template: s.template };
+    const resolvedPrompt = s[formatProp](params);
+    return { prompt: resolvedPrompt, template: s[templateProp] };
   }
   return { prompt: s, template: null };
 }

--- a/src/template.test.ts
+++ b/src/template.test.ts
@@ -1,28 +1,33 @@
-import { f, formatProp, objectTemplate, variablesProp } from "./template";
+import {
+  f,
+  formatTemplate,
+  getTemplateVariables,
+  objectTemplate,
+} from "./template";
 
 describe("templating", () => {
   describe("f", () => {
     it("should extract variables", () => {
-      expect(f`{a} {b} {c}`[variablesProp]).toEqual(["a", "b", "c"]);
+      expect(getTemplateVariables(f`{a} {b} {c}`)).toEqual(["a", "b", "c"]);
     });
 
     it("Should throw an error when using variables in a template string", () => {
       const a = "a";
       const b = "b";
       const c = "c";
-      expect(() => f`${a} ${b} ${c}`[variablesProp]).toThrow(
+      expect(() => getTemplateVariables(f`${a} ${b} ${c}`)).toThrow(
         "No inline variables",
       );
     });
 
     it("Should format to a string", () => {
-      expect(f`{a} {b} {c}`[formatProp]({ a: "A", b: "B", c: "C" })).toEqual(
-        "A B C",
-      );
+      expect(
+        formatTemplate(f`{a} {b} {c}`, { a: "A", b: "B", c: "C" }),
+      ).toEqual("A B C");
     });
 
     it("Should throw an error if any variable is missing during formatting", () => {
-      expect(() => f`{a} {b} {c}`[formatProp]({ a: "A", c: "C" })).toThrow(
+      expect(() => formatTemplate(f`{a} {b} {c}`, { a: "A", c: "C" })).toThrow(
         "missing variable",
       );
     });
@@ -31,57 +36,66 @@ describe("templating", () => {
   describe("objTemplate", () => {
     it("should extract variables from objects", () => {
       expect(
-        objectTemplate({ a: "A here: {a}", b: "B here: {b}" })[variablesProp],
+        getTemplateVariables(
+          objectTemplate({ a: "A here: {a}", b: "B here: {b}" }),
+        ),
       ).toEqual(["a", "b"]);
     });
 
     it("should extract variables from nested objects", () => {
       expect(
-        objectTemplate({
-          a: "A here: {a}",
-          b: "B here: {b}",
-          c: { d: "D here: {d}", e: "E here: {e}" },
-        })[variablesProp],
+        getTemplateVariables(
+          objectTemplate({
+            a: "A here: {a}",
+            b: "B here: {b}",
+            c: { d: "D here: {d}", e: "E here: {e}" },
+          }),
+        ),
       ).toEqual(["a", "b", "d", "e"]);
     });
 
     it("should extract variables from arrays", () => {
       expect(
-        objectTemplate(["A here: {a}", "B here: {b}"])[variablesProp],
+        getTemplateVariables(objectTemplate(["A here: {a}", "B here: {b}"])),
       ).toEqual(["a", "b"]);
     });
 
     it("Should handle nulls, undefined, and numbers in variable extraction", () => {
       expect(
-        objectTemplate({
-          a: "A here: {a}",
-          b: "B here: {b}",
-          c: { d: "D here: {d}", e: "E here: {e}" },
-          f: null,
-          g: undefined,
-          h: 1,
-        })[variablesProp],
+        getTemplateVariables(
+          objectTemplate({
+            a: "A here: {a}",
+            b: "B here: {b}",
+            c: { d: "D here: {d}", e: "E here: {e}" },
+            f: null,
+            g: undefined,
+            h: 1,
+          }),
+        ),
       ).toEqual(["a", "b", "d", "e"]);
     });
 
     it("Should format a chat template", () => {
       expect(
-        objectTemplate([
+        formatTemplate(
+          objectTemplate([
+            {
+              role: "system",
+              content:
+                "You will be asked for travel recomendations by a {role}. Answer as you were a travel guide and give no more than {quantity} recommendation options per answer. Just answer with the options and don't give any introduction. Use markdown to format your response.",
+            },
+            {
+              role: "user",
+              content: "Where can I eat {food} in {city}?",
+            },
+          ]),
           {
-            role: "system",
-            content:
-              "You will be asked for travel recomendations by a {role}. Answer as you were a travel guide and give no more than {quantity} recommendation options per answer. Just answer with the options and don't give any introduction. Use markdown to format your response.",
+            role: "tourist",
+            quantity: 3,
+            food: "pizza",
+            city: "Rome",
           },
-          {
-            role: "user",
-            content: "Where can I eat {food} in {city}?",
-          },
-        ])[formatProp]({
-          role: "tourist",
-          quantity: 3,
-          food: "pizza",
-          city: "Rome",
-        }),
+        ),
       ).toEqual([
         {
           role: "system",
@@ -97,43 +111,46 @@ describe("templating", () => {
 
     it("Should format a chat template with a chat history role", () => {
       expect(
-        objectTemplate([
-          {
-            role: "system",
-            content:
-              "You are a helpful assistant who guides executives on how to manage employees.",
-          },
-          {
-            role: "chat_history",
-            content: "{prev_messages} {second_history}",
-          },
-          {
-            role: "user",
-            content: "{question}",
-          },
-        ])[formatProp]({
-          prev_messages: [
+        formatTemplate(
+          objectTemplate([
+            {
+              role: "system",
+              content:
+                "You are a helpful assistant who guides executives on how to manage employees.",
+            },
+            {
+              role: "chat_history",
+              content: "{prev_messages} {second_history}",
+            },
             {
               role: "user",
-              content: "You are always late to work.",
+              content: "{question}",
             },
-            {
-              role: "assistant",
-              content: "I suggest you to be more polite.",
-            },
-          ],
-          second_history: [
-            {
-              role: "user",
-              content: "Is there something going on that makes you late?",
-            },
-            {
-              role: "assistant",
-              content: "That's a little better.",
-            },
-          ],
-          question: "Why are you being so short with me?",
-        }),
+          ]),
+          {
+            prev_messages: [
+              {
+                role: "user",
+                content: "You are always late to work.",
+              },
+              {
+                role: "assistant",
+                content: "I suggest you to be more polite.",
+              },
+            ],
+            second_history: [
+              {
+                role: "user",
+                content: "Is there something going on that makes you late?",
+              },
+              {
+                role: "assistant",
+                content: "That's a little better.",
+              },
+            ],
+            question: "Why are you being so short with me?",
+          },
+        ),
       ).toEqual([
         {
           role: "system",
@@ -165,11 +182,14 @@ describe("templating", () => {
 
     it("Should unescape escaped variable references", () => {
       expect(
-        objectTemplate({
-          a: "A here: \\{a\\}",
-          b: "B here: \\{b\\}",
-          c: { d: "D here: \\{d\\}", e: "E here: \\{e\\}" },
-        })[formatProp]({}),
+        formatTemplate(
+          objectTemplate({
+            a: "A here: \\{a\\}",
+            b: "B here: \\{b\\}",
+            c: { d: "D here: \\{d\\}", e: "E here: \\{e\\}" },
+          }),
+          {},
+        ),
       ).toEqual({
         a: "A here: {a}",
         b: "B here: {b}",
@@ -178,11 +198,14 @@ describe("templating", () => {
     });
     it("Should allow mixing of escaped and unescaped variable references", () => {
       expect(
-        objectTemplate({
-          a: "A here: \\{a\\} but this is the value of a: {a}",
-          b: "B here: \\{b\\}",
-          c: { d: "D here: \\{d\\}", e: "E here: \\{e\\}" },
-        })[formatProp]({ a: "Heya" }),
+        formatTemplate(
+          objectTemplate({
+            a: "A here: \\{a\\} but this is the value of a: {a}",
+            b: "B here: \\{b\\}",
+            c: { d: "D here: \\{d\\}", e: "E here: \\{e\\}" },
+          }),
+          { a: "Heya" },
+        ),
       ).toEqual({
         a: "A here: {a} but this is the value of a: Heya",
         b: "B here: {b}",

--- a/src/template.test.ts
+++ b/src/template.test.ts
@@ -1,26 +1,28 @@
-import { f, objectTemplate } from "./template";
+import { f, formatProp, objectTemplate, variablesProp } from "./template";
 
 describe("templating", () => {
   describe("f", () => {
     it("should extract variables", () => {
-      expect(f`{a} {b} {c}`.variables).toEqual(["a", "b", "c"]);
+      expect(f`{a} {b} {c}`[variablesProp]).toEqual(["a", "b", "c"]);
     });
 
     it("Should throw an error when using variables in a template string", () => {
       const a = "a";
       const b = "b";
       const c = "c";
-      expect(() => f`${a} ${b} ${c}`.variables).toThrow("No inline variables");
+      expect(() => f`${a} ${b} ${c}`[variablesProp]).toThrow(
+        "No inline variables",
+      );
     });
 
     it("Should format to a string", () => {
-      expect(f`{a} {b} {c}`.format({ a: "A", b: "B", c: "C" })).toEqual(
+      expect(f`{a} {b} {c}`[formatProp]({ a: "A", b: "B", c: "C" })).toEqual(
         "A B C",
       );
     });
 
     it("Should throw an error if any variable is missing during formatting", () => {
-      expect(() => f`{a} {b} {c}`.format({ a: "A", c: "C" })).toThrow(
+      expect(() => f`{a} {b} {c}`[formatProp]({ a: "A", c: "C" })).toThrow(
         "missing variable",
       );
     });
@@ -29,7 +31,7 @@ describe("templating", () => {
   describe("objTemplate", () => {
     it("should extract variables from objects", () => {
       expect(
-        objectTemplate({ a: "A here: {a}", b: "B here: {b}" }).variables,
+        objectTemplate({ a: "A here: {a}", b: "B here: {b}" })[variablesProp],
       ).toEqual(["a", "b"]);
     });
 
@@ -39,15 +41,14 @@ describe("templating", () => {
           a: "A here: {a}",
           b: "B here: {b}",
           c: { d: "D here: {d}", e: "E here: {e}" },
-        }).variables,
+        })[variablesProp],
       ).toEqual(["a", "b", "d", "e"]);
     });
 
     it("should extract variables from arrays", () => {
-      expect(objectTemplate(["A here: {a}", "B here: {b}"]).variables).toEqual([
-        "a",
-        "b",
-      ]);
+      expect(
+        objectTemplate(["A here: {a}", "B here: {b}"])[variablesProp],
+      ).toEqual(["a", "b"]);
     });
 
     it("Should handle nulls, undefined, and numbers in variable extraction", () => {
@@ -59,7 +60,7 @@ describe("templating", () => {
           f: null,
           g: undefined,
           h: 1,
-        }).variables,
+        })[variablesProp],
       ).toEqual(["a", "b", "d", "e"]);
     });
 
@@ -75,7 +76,7 @@ describe("templating", () => {
             role: "user",
             content: "Where can I eat {food} in {city}?",
           },
-        ]).format({
+        ])[formatProp]({
           role: "tourist",
           quantity: 3,
           food: "pizza",
@@ -110,7 +111,7 @@ describe("templating", () => {
             role: "user",
             content: "{question}",
           },
-        ]).format({
+        ])[formatProp]({
           prev_messages: [
             {
               role: "user",
@@ -168,7 +169,7 @@ describe("templating", () => {
           a: "A here: \\{a\\}",
           b: "B here: \\{b\\}",
           c: { d: "D here: \\{d\\}", e: "E here: \\{e\\}" },
-        }).format({}),
+        })[formatProp]({}),
       ).toEqual({
         a: "A here: {a}",
         b: "B here: {b}",
@@ -181,7 +182,7 @@ describe("templating", () => {
           a: "A here: \\{a\\} but this is the value of a: {a}",
           b: "B here: \\{b\\}",
           c: { d: "D here: \\{d\\}", e: "E here: \\{e\\}" },
-        }).format({ a: "Heya" }),
+        })[formatProp]({ a: "Heya" }),
       ).toEqual({
         a: "A here: {a} but this is the value of a: Heya",
         b: "B here: {b}",

--- a/src/template.ts
+++ b/src/template.ts
@@ -258,16 +258,15 @@ function handleChatHistory(item: any, params: any): any[] {
     );
   }
 
-  const allHistory = varsInChatHistory.reduce((acc, varName) => {
+  const allHistory = varsInChatHistory.map((varName) => {
     const value = params[varName];
     if (!value) {
       throw new Error(
         `No value was found in 'templateParams' for the variable '${varName}'. Ensure you have a corresponding entry in 'templateParams'.`,
       );
     }
-    acc.push(...value);
-    return acc;
-  }, [] as any[]);
+    return value;
+  });
 
-  return [...allHistory];
+  return allHistory;
 }

--- a/src/template.ts
+++ b/src/template.ts
@@ -79,10 +79,30 @@ export function f(
   };
 }
 
-export const formatProp = Symbol("format");
-export const templateProp = Symbol("template");
+const formatProp = Symbol("format");
 
-export const variablesProp = Symbol("variables");
+const templateProp = Symbol("template");
+
+const variablesProp = Symbol("variables");
+
+export function formatTemplate<T>(
+  o: ObjectTemplate<T>,
+  parameters: Record<string, any>,
+): T {
+  const format = o[formatProp];
+  return format(parameters);
+}
+
+export function getTemplate<T>(o: ObjectTemplate<T>): T {
+  return o[templateProp];
+}
+
+export function getTemplateVariables<T>(
+  o: ObjectTemplate<T>,
+): readonly string[] {
+  return o[variablesProp];
+}
+
 /**
  * A template for nested objects, most useful when constructing chat prompts.
  */

--- a/src/template.ts
+++ b/src/template.ts
@@ -258,7 +258,7 @@ function handleChatHistory(item: any, params: any): any[] {
     );
   }
 
-  const allHistory = varsInChatHistory.map((varName) => {
+  const allHistory = varsInChatHistory.flatMap((varName) => {
     const value = params[varName];
     if (!value) {
       throw new Error(

--- a/src/template.ts
+++ b/src/template.ts
@@ -24,8 +24,8 @@ const ROLE_KEY = "role";
  *
  * // exposes the following:
  * template.variables; // ["name"]
- * template.format({name: "World"}); // "Hello World!"
- * template.template; // "Hello {name}!"
+ * template[formatProp]({name: "World"}); // "Hello World!"
+ * template[templateProp]; // "Hello {name}!"
  * ```
  *
  *
@@ -59,7 +59,7 @@ export function f(
     ),
   );
   return {
-    format(parameters: Record<string, any>) {
+    [formatProp]: (parameters: Record<string, any>) => {
       return str
         .replace(templateExpressionVarName, (match, variableName) => {
           if (parameters[variableName] === undefined) {
@@ -74,29 +74,36 @@ export function f(
           (_match, variableName) => `{${variableName}}`,
         );
     },
-    variables: Object.freeze(variables),
-    template: str,
+    [variablesProp]: Object.freeze(variables),
+    [templateProp]: str,
   };
 }
 
+export const formatProp = Symbol("format");
+export const templateProp = Symbol("template");
+
+export const variablesProp = Symbol("variables");
 /**
  * A template for nested objects, most useful when constructing chat prompts.
  */
-export interface ObjectTemplate<T> {
+export interface ObjectTemplate_<T> {
   /**
    * A function that takes a dictionary of variable names to values, and returns the formatted object
    */
-  format(parameters: Record<string, any>): T;
+  [formatProp]: (parameters: Record<string, any>) => T;
   /**
    * The names of the variables used in the template
    */
-  variables: readonly string[];
+  [variablesProp]: readonly string[];
   /**
    * The original template object
    */
-  template: T;
+  [templateProp]: T;
 }
 
+export type ObjectTemplate<T> = T extends string
+  ? ObjectTemplate_<T>
+  : ObjectTemplate_<T> & T;
 /**
  * A template for nested objects, most useful when constructing chat prompts.
  *
@@ -109,9 +116,9 @@ export interface ObjectTemplate<T> {
  * }]);
  *
  * // exposes the following:
- * template.variables; // ["name"]
- * template.format({name: "World"}); // [{role: "user", content: "Hello World!"}]
- * template.template; // [{role: "user", content: "Hello {name}!"}]
+ * template[variablesProp]; // ["name"]
+ * template[formatProp]({name: "World"}); // [{role: "user", content: "Hello World!"}]
+ * template[templateProp]; // [{role: "user", content: "Hello {name}!"}]
  * ```
  *
  * @param objs The object to template
@@ -129,7 +136,7 @@ export function objectTemplate<T>(objs: T): ObjectTemplate<T> {
       return objs;
     }
     if (typeof objs == "string") {
-      return f(objs).format(parameters) as T;
+      return f(objs)[formatProp](parameters) as T;
     }
     if (Array.isArray(objs)) {
       return objs.flatMap((item) => {
@@ -139,24 +146,41 @@ export function objectTemplate<T>(objs: T): ObjectTemplate<T> {
           return handleChatHistory(item, parameters);
         }
 
-        return objectTemplate(item).format(parameters);
+        return objectTemplate(item)[formatProp](parameters);
       }) as T;
     }
 
     return Object.fromEntries(
       Object.entries(objs).map(([key, value]) => {
         return [
-          f(key).format(parameters),
-          objectTemplate(value).format(parameters),
+          f(key)[formatProp](parameters),
+          objectTemplate(value)[formatProp](parameters),
         ];
       }),
     ) as T;
   }
-  return {
-    format,
-    variables: Object.freeze(variables),
-    template: objs,
-  };
+  if (typeof objs == "string") {
+    return {
+      [formatProp]: format,
+      [variablesProp]: variables,
+      [templateProp]: objs,
+      toString: () => objs,
+    } as ObjectTemplate<T>;
+  }
+  if (typeof objs !== "object") {
+    throw new Error(
+      "Can only generate object templates for objects or strings",
+    );
+  }
+  const result = structuredClone(objs) as ObjectTemplate<T>;
+  result[formatProp] = format;
+  result[variablesProp] = Object.freeze(variables);
+  result[templateProp] = objs;
+  return result;
+}
+
+export function isObjectTemplate<T>(obj: any): obj is ObjectTemplate<T> {
+  return formatProp in obj && variablesProp in obj && templateProp in obj;
 }
 
 function objTemplateVariables(objs: any): readonly string[] {
@@ -164,7 +188,7 @@ function objTemplateVariables(objs: any): readonly string[] {
     return [];
   }
   if (typeof objs == "string") {
-    return f(objs).variables;
+    return f(objs)[variablesProp];
   }
 
   if (Array.isArray(objs)) {
@@ -172,7 +196,7 @@ function objTemplateVariables(objs: any): readonly string[] {
   }
   return Object.entries(objs).flatMap(([, value]): readonly string[] => {
     if (typeof value == "string") {
-      return f(value).variables;
+      return f(value)[variablesProp];
     }
     return objTemplateVariables(value);
   });


### PR DESCRIPTION
This basically allows you to use `objectTemplate()` and ``f`template {var}` ``  in a more typesafe manner, allowing you to say:

```ts
  const completion = await openai.chat.completions.create({
    // Instead of a chat message array, you can pass objectTemplate instead.
    messages: objectTemplate([
      { role: "user", content: "Give a hearty welcome to our new user {name}" },
    ]),
...
```

without any casting. This also makes it safer in case of key conflicts by using JS Symbols to guarantee unique slots.

- **switch to using private symbols and structuredClone**
- **switch to accesor functions**
