### PR TITLE
Send event errors to Libretto

### DIFF
--- a/src/chat.ts
+++ b/src/chat.ts
@@ -96,12 +96,13 @@ class LibrettoChatCompletions extends Completions {
       feedbackKey,
       true,
     );
-    let params = libretto?.templateParams ?? {};
+
     // note: not awaiting the result of this
     finalResultPromise
       .then(
         async ({ response, tool_calls, finish_reason, logprobs, usage }) => {
           const responseTime = Date.now() - now;
+          let params = libretto?.templateParams ?? {};
 
           // Redact PII before recording the event
           if (this.piiRedactor) {

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -12,7 +12,7 @@ import {
   Completions,
 } from "openai/resources/chat/completions";
 import { Stream } from "openai/streaming";
-import { LibrettoConfig, send_event } from ".";
+import { LibrettoConfig, LibrettoCreateParams, send_event } from ".";
 import { PiiRedactor } from "./pii";
 import {
   getResolvedMessages,
@@ -96,13 +96,12 @@ class LibrettoChatCompletions extends Completions {
       feedbackKey,
       true,
     );
-
+    let params = libretto?.templateParams ?? {};
     // note: not awaiting the result of this
     finalResultPromise
       .then(
         async ({ response, tool_calls, finish_reason, logprobs, usage }) => {
           const responseTime = Date.now() - now;
-          let params = libretto?.templateParams ?? {};
 
           // Redact PII before recording the event
           if (this.piiRedactor) {
@@ -123,34 +122,25 @@ class LibrettoChatCompletions extends Completions {
             ? reJsonToolCalls(tool_calls)
             : response;
 
-          await send_event({
+          await this.prepareAndSendEvent({
             responseTime,
             response: eventResponse,
-            responseMetrics: { usage, finish_reason, logprobs },
-            params: params,
-            apiKey:
-              libretto?.apiKey ??
-              this.config.apiKey ??
-              process.env.LIBRETTO_API_KEY,
-            promptTemplateChat:
-              libretto?.templateChat ?? template ?? resolvedMessages,
-            promptTemplateName: resolvedPromptTemplateName,
-            apiName:
-              libretto?.promptTemplateName ?? this.config.promptTemplateName,
-            prompt: {},
-            chatId: libretto?.chatId ?? this.config.chatId,
-            parentEventId: libretto?.parentEventId,
+            params,
             feedbackKey,
-            modelParameters: {
-              modelProvider: "openai",
-              modelType: "chat",
-              ...openaiBody,
-            },
-            tools: tools,
+            template,
+            resolvedPromptTemplateName,
+            resolvedMessages,
+            tools,
+            usage,
+            finish_reason,
+            logprobs,
+            librettoParams: libretto,
+            openaiBody,
           });
         },
       )
       .catch(async (error) => {
+        const responseTime = Date.now() - now;
         // Capture OpenAI API errors here
         let params = libretto?.templateParams ?? {};
 
@@ -163,29 +153,95 @@ class LibrettoChatCompletions extends Completions {
             console.log("Failed to redact PII", err);
           }
         }
-
-        await send_event({
+        await this.prepareAndSendEvent({
+          responseTime,
           responseErrors: [JSON.stringify(error.response)],
-          responseTime: Date.now() - now,
-          apiKey:
-            libretto?.apiKey ??
-            this.config.apiKey ??
-            process.env.LIBRETTO_API_KEY,
-          promptTemplateName: resolvedPromptTemplateName,
-          promptTemplateChat: template ?? resolvedMessages,
-          prompt: {},
           params,
-          chatId: libretto?.chatId ?? this.config.chatId,
-          parentEventId: libretto?.parentEventId,
           feedbackKey,
-          modelParameters: {
-            modelProvider: "openai",
-            modelType: "chat",
-            ...openaiBody,
-          },
+          template,
+          resolvedPromptTemplateName,
+          resolvedMessages,
           tools,
+          librettoParams: libretto,
+          openaiBody,
         });
       });
     return returnValue as ChatCompletion | Stream<ChatCompletionChunk>;
+  }
+
+  protected async prepareAndSendEvent({
+    response,
+    responseTime,
+    responseErrors,
+    params,
+    librettoParams,
+    usage,
+    template,
+    resolvedMessages,
+    resolvedPromptTemplateName,
+    finish_reason,
+    logprobs,
+    openaiBody,
+    feedbackKey,
+    tools,
+  }: {
+    response?: string | null | undefined;
+    responseTime?: number;
+    responseErrors?: string[];
+    params: Record<string, any>;
+    librettoParams: LibrettoCreateParams | undefined;
+    template: Core.Chat.Completions.ChatCompletionMessageParam[] | null;
+    resolvedMessages: Core.Chat.Completions.ChatCompletionMessageParam[];
+    resolvedPromptTemplateName?: string | undefined;
+    usage?: Core.Completions.CompletionUsage | undefined;
+    finish_reason?:
+      | OpenAI.Completions.CompletionChoice["finish_reason"]
+      | OpenAI.ChatCompletion.Choice["finish_reason"]
+      | undefined
+      | null;
+    logprobs?:
+      | OpenAI.Completions.CompletionChoice.Logprobs
+      | OpenAI.Chat.Completions.ChatCompletion.Choice.Logprobs
+      | undefined
+      | null;
+    openaiBody: any;
+    feedbackKey?: string;
+    tools: Core.Chat.Completions.ChatCompletionTool[] | undefined;
+  }) {
+    const responseMetrics =
+      !usage && !finish_reason && !logprobs
+        ? {
+            usage,
+            finish_reason,
+            logprobs,
+          }
+        : undefined;
+
+    await send_event({
+      responseTime,
+      response,
+      responseErrors,
+      responseMetrics,
+      params: params,
+      apiKey:
+        librettoParams?.apiKey ??
+        this.config.apiKey ??
+        process.env.LIBRETTO_API_KEY,
+      promptTemplateChat:
+        librettoParams?.templateChat ?? template ?? resolvedMessages,
+      promptTemplateName: resolvedPromptTemplateName,
+      apiName:
+        librettoParams?.promptTemplateName ?? this.config.promptTemplateName,
+      prompt: {},
+      chatId: librettoParams?.chatId ?? this.config.chatId,
+      parentEventId: librettoParams?.parentEventId,
+      feedbackKey,
+      modelParameters: {
+        modelProvider: "openai",
+        modelType: "chat",
+        ...openaiBody,
+      },
+      tools: tools,
+    });
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export type LibrettoConfig = {
   chatId?: string;
 };
 
-type LibrettoCreateParams = {
+export type LibrettoCreateParams = {
   apiKey?: string;
   promptTemplateName?: string;
   templateText?: string;

--- a/src/runs.ts
+++ b/src/runs.ts
@@ -86,7 +86,7 @@ export class LibrettoRuns extends Runs {
         responseErrors: [JSON.stringify(run.last_error)],
         params: {},
         apiKey:
-          params?.opts?.apiKey ??
+          librettoParams?.opts?.apiKey ??
           this.config.apiKey ??
           process.env.LIBRETTO_API_KEY,
         promptTemplateChat: [
@@ -101,7 +101,9 @@ export class LibrettoRuns extends Runs {
         ],
         promptTemplateName: assistant.name ?? assistant.id,
         apiName:
-          params?.opts?.promptTemplateName ?? assistant.name ?? assistant.id,
+          librettoParams?.opts?.promptTemplateName ??
+          assistant.name ??
+          assistant.id,
         prompt: {},
         chatId: threadId,
       });

--- a/src/runs.ts
+++ b/src/runs.ts
@@ -82,7 +82,7 @@ export class LibrettoRuns extends Runs {
         responseErrors: [JSON.stringify(run.last_error)],
         params: {},
         apiKey:
-          params.opts?.apiKey ??
+          params?.opts?.apiKey ??
           this.config.apiKey ??
           process.env.LIBRETTO_API_KEY,
         promptTemplateChat: [
@@ -97,7 +97,7 @@ export class LibrettoRuns extends Runs {
         ],
         promptTemplateName: assistant.name ?? assistant.id,
         apiName:
-          params.opts?.promptTemplateName ?? assistant.name ?? assistant.id,
+          params?.opts?.promptTemplateName ?? assistant.name ?? assistant.id,
         prompt: {},
         chatId: threadId,
       });


### PR DESCRIPTION
- send error events to Libretto via .catch to the completions and chat promises
- check for `failed`, `incomplete`, and `cancelled` statuses for assistants, and send an error event to Libretto if reached