### PR TITLE
Adding debug flag for console to avoid spamming logs

### DIFF
--- a/src/assistants.ts
+++ b/src/assistants.ts
@@ -19,7 +19,9 @@ export class ThreadManager {
       try {
         await fn();
       } catch (err) {
-        console.error(`[Libretto] Error processing thread: ${err}`);
+        if (process.env.LIBRETTO_DEBUG === "true") {
+          console.error(`[Libretto] Error processing thread: ${err}`);
+        }
       }
     });
   }

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -115,7 +115,7 @@ class LibrettoChatCompletions extends Completions {
               argsAsJson: redactor.redact(tool_call.argsAsJson),
             }));
           } catch (err) {
-            console.log("Failed to redact PII", err);
+            console.warn("Failed to redact PII", err);
           }
         }
         const eventResponse = tool_calls.length

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -97,7 +97,7 @@ export class LibrettoCompletions extends Completions {
             response = this.piiRedactor.redact(response);
             params = this.piiRedactor.redact(params);
           } catch (err) {
-            console.log("Failed to redact PII", err);
+            console.warn("Failed to redact PII", err);
           }
         }
 

--- a/src/runs.ts
+++ b/src/runs.ts
@@ -69,9 +69,11 @@ export class LibrettoRuns extends Runs {
       librettoParams.runId,
     );
     if (run.status !== "completed") {
-      console.log(
-        `[Libretto] Assistant thread run did not complete, ignoring: threadId=${threadId} runId=${librettoParams.runId}`,
-      );
+      if (process.env.LIBRETTO_DEBUG === "true") {
+        console.log(
+          `[Libretto] Assistant thread run did not complete, ignoring: threadId=${threadId} runId=${librettoParams.runId}`,
+        );
+      }
       return;
     }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -101,7 +101,9 @@ export async function send_event(event: Event) {
 
     return responseJson;
   } catch (e) {
-    console.error("Failed to send event to libretto:", e);
+    if (process.env.LIBRETTO_DEBUG === "true") {
+      console.error("Failed to send event to libretto:", e);
+    }
   }
 }
 async function extractJsonBody(response: Response) {


### PR DESCRIPTION
When we go down (or have errors), we can end up spamming our customers' logs. This PR takes a bunch of the console calls and puts them behind a LIBRETTO_DEBUG flag. It tries to do this with LLM outputs rather than inputs, where the errors are still reported.