### PR TITLE
Adjust logic to send responseMetrics & bumps version 1.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@libretto/openai",
   "main": "lib/src/index.js",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "types": "lib/src/index.d.ts",
   "repository": {
     "type": "git",

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -209,20 +209,11 @@ class LibrettoChatCompletions extends Completions {
     feedbackKey?: string;
     tools: Core.Chat.Completions.ChatCompletionTool[] | undefined;
   }) {
-    const responseMetrics =
-      !usage && !finish_reason && !logprobs
-        ? {
-            usage,
-            finish_reason,
-            logprobs,
-          }
-        : undefined;
-
     await send_event({
       responseTime,
       response,
       responseErrors,
-      responseMetrics,
+      responseMetrics: { usage, finish_reason, logprobs },
       params: params,
       apiKey:
         librettoParams?.apiKey ??

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -182,20 +182,15 @@ export class LibrettoCompletions extends Completions {
     feedbackKey?: string;
     resolvedPromptStr?: string | null;
   }) {
-    const responseMetrics =
-      !usage && !finish_reason && !logprobs
-        ? {
-            usage,
-            finish_reason,
-            logprobs,
-          }
-        : undefined;
-
     await send_event({
       responseTime,
       response,
       responseErrors,
-      responseMetrics,
+      responseMetrics: {
+        usage,
+        finish_reason,
+        logprobs,
+      },
       params,
       apiKey:
         librettoParams?.apiKey ??


### PR DESCRIPTION
- logic branching prevented `responseMetrics` from being sent correctly