### PR TITLE
v1.2.1: Downgrade p-limit because of ERR_REQUIRE_ESM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@libretto/openai",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@libretto/openai",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "dependencies": {
         "@libretto/redact-pii-light": "^1.0.1",
         "limiter": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@libretto/openai",
   "main": "lib/src/index.js",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "types": "lib/src/index.d.ts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
See https://stackoverflow.com/questions/69956414/how-to-import-node-module-in-typescript-project-err-require-esm