### PR TITLE
Re-add templateChat as an option to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ added to the base OpenAI `create` call interface:
   conversational context, then the same chat id can be provided so that the
   events are grouped together, in order. If not provided, this will be left
   blank.
+- `templateChat`: The chat _template_ to record for chat requests. This is a
+  list of dictionaries with the following keys:
+  - `role`: The role of the speaker. Either `"system"`, `"user"` or `"ai"`.
+  - `content`: The content of the message. This can be a string or a template
+    string with `{}` placeholders.
 - `chainId`: A UUID that groups related events together in a chain. For example,
   if you have a multi-step workflow where one LLM call's output feeds into another
   LLM call, you can use the same chainId to track the full sequence of events.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ added to the base OpenAI `create` call interface:
   list of dictionaries with the following keys:
   - `role`: The role of the speaker. Either `"system"`, `"user"` or `"ai"`.
   - `content`: The content of the message. This can be a string or a template
-    string with `{}` placeholders.
+    string with `{}` placeholders. 
 - `chainId`: A UUID that groups related events together in a chain. For example,
   if you have a multi-step workflow where one LLM call's output feeds into another
   LLM call, you can use the same chainId to track the full sequence of events.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@libretto/openai",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@libretto/openai",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "dependencies": {
         "@libretto/redact-pii-light": "^1.0.1",
         "limiter": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@libretto/openai",
   "main": "lib/src/index.js",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "types": "lib/src/index.d.ts",
   "repository": {
     "type": "git",

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -215,7 +215,8 @@ class LibrettoChatCompletions extends Completions {
         librettoParams?.apiKey ??
         this.config.apiKey ??
         process.env.LIBRETTO_API_KEY,
-      promptTemplateChat: template ?? resolvedMessages,
+      promptTemplateChat:
+        librettoParams?.templateChat ?? template ?? resolvedMessages,
       promptTemplateName: resolvedPromptTemplateName,
       apiName:
         librettoParams?.promptTemplateName ?? this.config.promptTemplateName,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import { ChatCompletionMessage } from "openai/resources/chat";
+
 export { OpenAI } from "./client";
 export { Event, Feedback, send_event, sendFeedback } from "./session";
 export { f, objectTemplate } from "./template";
@@ -15,6 +17,7 @@ export type LibrettoCreateParams = {
   apiKey?: string;
   promptTemplateName?: string;
   templateParams?: Record<string, any>;
+  templateChat?: ChatCompletionMessage[];
   chatId?: string;
   chainId?: string;
   feedbackKey?: string;


### PR DESCRIPTION
We removed this, but it can still be used by people, especially of a way to get around needing to use objectTemplate in some environments.